### PR TITLE
fix: cannot find `/dev/sda1`

### DIFF
--- a/scripts/lay-down-os
+++ b/scripts/lay-down-os
@@ -28,7 +28,7 @@ device_defined()
 
 format_device()
 {
-    mkfs.ext4 -F -L RANCHER_STATE ${DEVICE}1
+    mkfs.ext4 -F -L RANCHER_STATE ${DEVICE}
 }
 
 mount_device() 


### PR DESCRIPTION
I've tried to run `sudo rancheros-install -d /dev/sda -c ./vagrant.yml -v v0.1.2 -t virtualbox-iso`
Looks like it failed (with the following messages):

```
+ format_device
+ mkfs.ext4 -F -L RANCHER_STATE /dev/sda1
mke2fs 1.42.12 (29-Aug-2014)
The file /dev/sda1 does not exist and no size was specified.
```
