### PR TITLE
Speed up Grub (same time as CoreOS)

### DIFF
--- a/scripts/lay-down-os
+++ b/scripts/lay-down-os
@@ -56,7 +56,7 @@ grub2_config(){
 local grub_cfg=${BASE_DIR}/boot/grub/grub.cfg
 cat >$grub_cfg <<EOF
 set default="0"
-set timeout="2"
+set timeout="1"
 #set fallback=1
 
 menuentry "RancherOS-current" {


### PR DESCRIPTION
Speeding up boot-time of RancherOS by changing timeout to 1.
